### PR TITLE
© Copy/Paste from Context Menu

### DIFF
--- a/source/assets/js/srf-comments.js
+++ b/source/assets/js/srf-comments.js
@@ -13,7 +13,7 @@ let commentController = function () {
 
     this.init = function () {
 
-        $('.js-article-comments').on('keyup focus', '.reply__textarea', function (e) {
+        $('.js-article-comments').on('keyup focus input', '.reply__textarea', function (e) {
             that.countChars($(this));
         }).on('focusin', '.reply__textarea', function () {
             $('.reply').addClass('reply--on-focus');


### PR DESCRIPTION
**SRFCMSAL-809**

Ist: Wird ein Kommentar über das Kontextmenü eingefügt, aktualisiert der Zähler nicht die Anzahl der Zeichen. Der Kommentar lässt sich auch nicht abschicken bis der User nicht einen weiteren Klick auf der Seite ausübt (siehe Screenshot). Bei ctrl+c / ctrl+v tritt der Fehler nicht auf.
Soll: Der Zähler sollte sich nach Einfügen des Textes aktualisieren und den Kommentieren-Button aktivieren (wenn die Zeichenanzahl nicht überschritten wird).
