### PR TITLE
SRFCMSAL-904 restrict global link styles

### DIFF
--- a/source/_patterns/20-molecules/article-content/article-content.scss
+++ b/source/_patterns/20-molecules/article-content/article-content.scss
@@ -39,9 +39,13 @@
       margin: 12px 0 20px;
     }
   }
-}
 
-@include link-text-inline;
+  // only apply default text link styling to links without a class (i.e. body text from our CMS)
+  a:not([class]),
+  a[class=""] {
+    @include text-link-defaults;
+  }
+}
 
 ul {
   // @extend used here to apply the DRY principle while coping with ezxml's missing classes for html elements

--- a/source/_patterns/20-molecules/comments/comments.scss
+++ b/source/_patterns/20-molecules/comments/comments.scss
@@ -86,6 +86,9 @@
 // login info
 .comments-header__text {
   margin: 0 0 24px;
+  a {
+    @include text-link-defaults;
+  }
 }
 
 // info: there are no comments yet ...

--- a/source/_patterns/20-molecules/medium/medium--video-gallery.twig
+++ b/source/_patterns/20-molecules/medium/medium--video-gallery.twig
@@ -1,4 +1,4 @@
-<a href="#LINK_TO_PLAYER">
+<a href="#LINK_TO_PLAYER" class="medium-wrapper-link">
     <div class="medium medium--vertical medium--video-gallery js-medium-hover">
         <div class="medium__object">
             {% include 'molecules-media-still--video' with { 'styleModifier' : '' } %}

--- a/source/_patterns/_globals.scss
+++ b/source/_patterns/_globals.scss
@@ -33,6 +33,15 @@ h4 {
 
 a {
   text-decoration: none;
+  color: $color-link-default;
+
+  &:hover {
+    color: $color-link-hover;
+  }
+
+  &:active {
+    color: $color-link-active;
+  }
 
   &:hover,
   &:active,

--- a/source/_patterns/_mixins.scss
+++ b/source/_patterns/_mixins.scss
@@ -69,21 +69,16 @@
   }
 }
 
-@mixin link-text-inline {
-  a {
-    color: $color-link-default;
+@mixin text-link-defaults {
     border-bottom: 1px solid $color-link-default;
 
     &:hover {
-      color: $color-link-hover;
       border-bottom: 1px solid $color-link-hover;
     }
 
     &:active {
-      color: $color-link-active;
       border-bottom: 1px solid $color-link-active;
     }
-  }
 }
 
 @mixin button-label {


### PR DESCRIPTION
moving the global link color definitions from article_content.css to globals.scss for transparency; apply default text link styles (border-bottom) only to links without class attribute or empty class attributes in article_content.

SRFCMSAL-904