### PR TITLE
Deactivates convertShapeToPath (svg optimizer; svgo; svgmin)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ gulp.task('images', function() {
         .pipe(imagemin([
             imagemin.gifsicle(),
             imagemin.optipng(),
-            imagemin.svgo({plugins: [{convertShapeToPath: false}]})
+            imagemin.svgo()
         ]))
         .pipe(gulp.dest('public/assets/img'))
 });


### PR DESCRIPTION
Because of pixelated search-icon in header if path-optimizations is activated