### PR TITLE
fixes touch detection

### DIFF
--- a/source/assets/js/classes/fef-touch-detection.js
+++ b/source/assets/js/classes/fef-touch-detection.js
@@ -6,7 +6,7 @@ export class FefTouchDetection {
      * @returns {boolean}
      */
     static isTouchSupported() {
-        return ('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch;
+        return ('ontouchstart' in window) || typeof window.DocumentTouch !== 'undefined' && document instanceof DocumentTouch;
     }
 
 }


### PR DESCRIPTION
explanation: in JS short-circuit evaluation can be used for variable assignment;
window.DocumentTouch is 'undefined': b = false || undefined does return undefined and not false.