### PR TITLE
fix close btn position in IE11

### DIFF
--- a/source/_patterns/30-organisms/modal/modal-player.scss
+++ b/source/_patterns/30-organisms/modal/modal-player.scss
@@ -47,7 +47,7 @@
 .modal-player__close {
   display: flex;
   justify-content: flex-end;
-  align-items: self-start;
+  align-items: flex-start;
 }
 
 .modal-player__loading,


### PR DESCRIPTION
noref-uboot