### PR TITLE
SRFCMSAL-1189 minor display fix in livecenter-teaser

### DIFF
--- a/source/_patterns/20-molecules/scoreboard/scoreboard.scss
+++ b/source/_patterns/20-molecules/scoreboard/scoreboard.scss
@@ -70,6 +70,7 @@ $scoreboard-col-padding-height: 8px;
 .scoreboard__rank {
   width: 20px;
   flex-grow: 0;
+  flex-shrink: 0;
   line-height: 14px;
 }
 


### PR DESCRIPTION
fixes missing space between rank and flag when a competitor has a very long name and the teaser istn't very wide

SRFCMSAL-1189