### PR TITLE
SRFCMSAL-1812 Add borderless collection/static teaser to critical css

### DIFF
--- a/source/_patterns/50-pages/30-critical/landingpage-critical.twig
+++ b/source/_patterns/50-pages/30-critical/landingpage-critical.twig
@@ -3,6 +3,15 @@
         {% for collection in collections %}
             {% include 'organisms-collection' with {'collection': collection} %}
         {% endfor %}
+
+        {% include 'organisms-collection' with {
+            'collection': {
+                "styleModifier": "collection--standard collection--borderless",
+                "title": "You should never see this",
+                "lead": "You should never see this",
+                "teasers": collections[0].teasers[0:1]
+            }
+        } %}
     {% endblock %}
 
     {% block demo_content %}

--- a/source/assets/critical/c_landingpage.scss
+++ b/source/assets/critical/c_landingpage.scss
@@ -191,6 +191,13 @@ body.body--loading.body--loading {
     }
   }
 
+  // Borderless: teasers + teaser-items take up 100% of the width
+  .collection--borderless {
+    .collection__teaser-item {
+      width: 100%;
+    }
+  }
+
   // Selectable: Hide the selection element, show the first collection after it.
   // From that collection, only show the first 3 teasers
   .selectable {
@@ -322,6 +329,10 @@ body.body--loading.body--loading {
 
   .ratio--16-9::before {
     padding-top: 56.25%;
+  }
+
+  .teaser--static {
+    width: 100%;
   }
 
   .teaser--size-xl {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/21658108/51034688-d8a62680-15a7-11e9-9ba8-97b5299987a1.png)
After:
![image](https://user-images.githubusercontent.com/21658108/51034713-ebb8f680-15a7-11e9-892b-b897383aee74.png)


Yes, still looks bad but now meteo-devs can implement their own loading state 🙌