### PR TITLE
SRFCMSAL-1919: show bottom gap to branding wrapper in compact collection + demo

### DIFF
--- a/source/_patterns/30-organisms/collection/collection.scss
+++ b/source/_patterns/30-organisms/collection/collection.scss
@@ -263,6 +263,7 @@ $background-overlap-wide: 50px;
 
   // mobile first: teaser items have 8px margin between them (after the item), except the last one, which has none.
   margin: 0 0 8px;
+
   &:last-child {
     margin-bottom: 0;
   }
@@ -509,8 +510,10 @@ $background-overlap-wide: 50px;
 
 // Compact: S teasers only. 2 columns on tablet. Desktop: 2 columns, except if 3 teasers --> then 3 columns
 .collection--compact {
-  .collection__teaser-list {
-    margin-bottom: 0;
+  @include tablet-up {
+    .collection__teaser-list {
+      margin-bottom: 0;
+    }
   }
 
   .collection__teaser-item {

--- a/source/_patterns/30-organisms/collection/demo-collection.twig
+++ b/source/_patterns/30-organisms/collection/demo-collection.twig
@@ -416,11 +416,11 @@
 </div>
 
 <div class="js-collection-wrapper">
-    <h3>Compact, 5 Teaser</h3>
+    <h3>Compact, 5 Teaser, Branded</h3>
     <div class="js-collection-wrapper-content">
     {% include 'organisms-collection' with {
         'collection': {
-            'styleModifier': 'collection--compact',
+            'styleModifier': 'collection--compact collection--branded',
             "title": "News Schweiz",
             "type": "standard",
             "teasers": collections[0].teasers[0:5]


### PR DESCRIPTION
Links: vorher
rechts: nachher

![image](https://user-images.githubusercontent.com/21658108/51894070-11673d80-23a7-11e9-9572-579792464121.png)
