### PR TITLE
SRFCMSAL-2049 - Bugfix RTR Logo in preloading state

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -97,7 +97,11 @@ gulp.task('images', function() {
         .pipe(imagemin([
             imagemin.gifsicle(),
             imagemin.optipng(),
-            imagemin.svgo()
+            imagemin.svgo({
+                plugins: [
+                    {removeViewBox: false}
+                ]
+            })
         ]))
         .pipe(gulp.dest('public/assets/img'))
 });

--- a/source/_patterns/10-atoms/navigation/search.scss
+++ b/source/_patterns/10-atoms/navigation/search.scss
@@ -7,10 +7,6 @@
   overflow: visible;
 }
 
-.search--active.search--z-indexed {
-  z-index: 200;
-}
-
 .search__close {
   display: none;
   text-decoration: none;
@@ -46,6 +42,8 @@
     background-color: #fefefd;
     border: 1px solid rgba(0,0,0,.08);
     border-bottom: 0;
+    position: relative;
+    z-index: 1;
   }
 }
 

--- a/source/_patterns/_shame.scss
+++ b/source/_patterns/_shame.scss
@@ -114,6 +114,32 @@ _:-ms-fullscreen,
       background-image: url(../img/icon/close-white.svg);
     }
   }
+
+  .search-wrapper {
+    background-color: rgba(0,0,0,.2);
+    border: 1px solid rgba(255,255,255,.12);
+
+    .search-input {
+      color: #fff;
+    }
+
+    .search-icon {
+      background-position: 10px -32px;
+    }
+  }
+
+  .search--active {
+    .search-wrapper {
+      box-shadow: $shadow-elevation4;
+      background-color: #fefefd;
+      border: 1px solid rgba(0,0,0,.08);
+      border-bottom: 0;
+    }
+
+    .search-input {
+      color: #000;
+    }
+  }
 }
 
 
@@ -132,7 +158,6 @@ _:-ms-fullscreen,
     }
   }
 }
-
 
 /*
  * TARGETED BROWSER: Safari

--- a/source/assets/critical/_header.scss
+++ b/source/assets/critical/_header.scss
@@ -82,6 +82,11 @@
   height: 24px;
   background-color: $color-srf;
   overflow: hidden;
+
+  img {
+    width: 100%;
+    height: auto;
+  }
 }
 
 .main-logo--large {

--- a/source/assets/img/rtr_logo.svg
+++ b/source/assets/img/rtr_logo.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="24px" height="16px" viewBox="0 0 24 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="24px" height="16px" viewBox="0 0 24 16" preserveAspectRatio="xMinYMin meet" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 43.2 (39069) - http://www.bohemiancoding.com/sketch -->
     <title>RTR-RGB v8</title>
     <desc>Created with Sketch.</desc>

--- a/source/assets/img/srf_logo.svg
+++ b/source/assets/img/srf_logo.svg
@@ -1,4 +1,4 @@
-<svg viewBox="0 0 304 200" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 304 200" preserveAspectRatio="xMinYMin meet" xmlns="http://www.w3.org/2000/svg">
 	<title>SRF Logo</title>
 	<g fill="none" fill-rule="evenodd">
 		<path fill="#AF001E" d="M0 200h304V0H0"/>

--- a/source/assets/img/stationlogos/tv-srf-1.svg
+++ b/source/assets/img/stationlogos/tv-srf-1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="41px" height="24px" viewBox="0 0 41 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="41px" height="24px" viewBox="0 0 41 24" preserveAspectRatio="xMinYMin meet" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 51.1 (57501) - http://www.bohemiancoding.com/sketch -->
     <title>SRF1</title>
     <desc>Created with Sketch.</desc>

--- a/source/assets/img/stationlogos/tv-srf-info.svg
+++ b/source/assets/img/stationlogos/tv-srf-info.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="67px" height="24px" viewBox="0 0 67 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="67px" height="24px" viewBox="0 0 67 24" preserveAspectRatio="xMinYMin meet" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 51.1 (57501) - http://www.bohemiancoding.com/sketch -->
     <title>SRFinfo</title>
     <desc>Created with Sketch.</desc>

--- a/source/assets/img/stationlogos/tv-srf-zwei.svg
+++ b/source/assets/img/stationlogos/tv-srf-zwei.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="75px" height="24px" viewBox="0 0 75 24" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg width="75px" height="24px" viewBox="0 0 75 24" preserveAspectRatio="xMinYMin meet" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <!-- Generator: Sketch 51.1 (57501) - http://www.bohemiancoding.com/sketch -->
     <title>SRFzwei</title>
     <desc>Created with Sketch.</desc>


### PR DESCRIPTION
Eigentlich geht es hier nur um das file:
source/assets/critical/_header.scss

Das RTR Logo ist viel kleiner als das SRF. Deswegen müssten wir es schon im critical auf 100% aufspannen.