### PR TITLE
SRFCMSAL-2156 Readds 3-column-view for OnAirNav on Tablet

### DIFF
--- a/source/_patterns/20-molecules/onairnav/onairnav.scss
+++ b/source/_patterns/20-molecules/onairnav/onairnav.scss
@@ -42,15 +42,14 @@
     margin: 0;
     padding: 0;
 
-    @include tablet {
-      flex-basis: calc(33.3334% - 2 * 12px);
-      margin: 0 12px;
-    }
-
     @include tablet-up {
       display: flex;
       flex-direction: column;
-      flex-basis: 100%;
+    }
+
+    @include tablet {
+      flex-basis: calc(33.3334% - 2 * 12px);
+      margin: 0 12px;
     }
 
     @include desktop-up {


### PR DESCRIPTION
This one reorders *tablet*- and *tablet-up*-mediaqueries to (hopefully) eliminate any future mix-up of potential `flex-basis`-declarations in the wrong mq ;-) … and it removes the bespoken `flex-basis` declaration.