### PR TITLE
SRFCMSAL-2138: Remove scrollbars via CSS (browser-dependent)

### DIFF
--- a/source/_patterns/20-molecules/swipable-area/swipeable-area.scss
+++ b/source/_patterns/20-molecules/swipable-area/swipeable-area.scss
@@ -49,6 +49,7 @@
   width: 100%;
   box-sizing: content-box;
   -webkit-overflow-scrolling: touch; // enable momentum scrolling on ios
+  @include preventScrollbars();
 
   // Direct child (usually an <ul>) can be animated by the hinting mechanism (See fef-swipeable-area.js:hintOn/hintOff)
   > * {

--- a/source/_patterns/20-molecules/swipe-module/swipe-module.scss
+++ b/source/_patterns/20-molecules/swipe-module/swipe-module.scss
@@ -147,10 +147,7 @@ $item-max-width: 400px;
     padding: 0 #{$container-padding-desktop-wide};
   }
 
-  // Browser-specific way to disable scrollbars - non-trivial with flex layout otherwise!
-  &::-webkit-scrollbar {
-    display: none;
-  }
+  @include preventScrollbars();
 
   // The gap between right container border and last item must be done with the :after pseudo element
   &::after {

--- a/source/_patterns/_mixins.scss
+++ b/source/_patterns/_mixins.scss
@@ -408,3 +408,24 @@
     @content;
   }
 }
+
+/**
+ * Prevents scrollbars with CSS only. Might not work on certain browsers or
+ * lead to side effects. Use at your own risk!
+ * 
+ * Usage:
+ *    @include preventScrollbars();
+ */
+@mixin preventScrollbars {
+  // webkit-based
+  &::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+  
+  // firefox 64+
+  scrollbar-width: none;
+  
+  // edge/ie (autohiding, but they appear again on interaction)
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+}

--- a/source/assets/js/components/fef-swipeable-area.js
+++ b/source/assets/js/components/fef-swipeable-area.js
@@ -63,22 +63,6 @@ export class FefSwipeableArea {
         }
     }
 
-    // the size of the outer container must be explicitly set in order to hide the scrollbar
-    // of the wrapper. To get the correct height, we set overflow to hidden to remove any
-    // potential scrollbars, then get the height and set it to the element before re-
-    // enabling the scrollbars on the inner wrapper. This also enables us to use the
-    // same mechanism on mobiles (i.e. iOS) where there's no scrollbars.
-    // This also causes issues with IE11. Disabled for now.
-    initContainerHeight() {
-        this.$innerContainer.css('overflow', 'hidden');
-        let height = this.$innerContainer.outerHeight();
-
-        if (height > MINIMUM_HEIGHT) {
-            this.$element.css('height', Math.floor(height));
-        }
-        this.$innerContainer.css('overflow', '');
-    }
-
     initItemCheck() {
         const markVisibleClass = this.$element.data('mark-visible-items');
         const markHiddenClass = this.$element.data('mark-hidden-items');


### PR DESCRIPTION
The following browsers should have no more scrollbars below swipeable collections:
* Chrome 4+
* Safari 5+
* Firefox 64+
* others (https://caniuse.com/#feat=css-scrollbar)

IE/Edge should hide the scrollbar when it's not in use (i.e. being scrolled)