### PR TITLE
add h-element-invisible to critical css because it is much more usefu…

### DIFF
--- a/source/assets/critical/_global.scss
+++ b/source/assets/critical/_global.scss
@@ -39,6 +39,10 @@ a {
   display: none !important
 }
 
+.h-element--invisible {
+  visibility: hidden;
+}
+
 .l-content-wrapper {
   margin: 0 auto;
   max-width: 1200px;


### PR DESCRIPTION
…l than h-element-hide to prevent jumps while loading