### PR TITLE
Podcast Flyout Goes Modal

### DIFF
--- a/source/_patterns/30-organisms/modal/modal-show.twig
+++ b/source/_patterns/30-organisms/modal/modal-show.twig
@@ -5,6 +5,8 @@
 }
 %}
 
+<p style="height: 200vh;">Scrollable</p>
+
 {% embed "modal.twig" with {
     'id': 'modal-show',
     'animation': 'slide-from-bottom',

--- a/source/_patterns/30-organisms/modal/modal.scss
+++ b/source/_patterns/30-organisms/modal/modal.scss
@@ -32,6 +32,11 @@ $modal-z-index: 100;
   box-shadow: $shadow-elevation8;
   z-index: $modal-z-index;
 
+  // we prevent scrolling on the body when the modal is taller than the
+  // viewport via JS (see fef-modal.js@preventScrolling()), but
+  // overscroll-behavior already does that on browsers that support it.
+  overscroll-behavior: contain;
+
   @include smartphone {
 
     &::after {

--- a/source/_patterns/30-organisms/modal/modal.scss
+++ b/source/_patterns/30-organisms/modal/modal.scss
@@ -139,16 +139,17 @@ $modal-z-index: 100;
   }
 }
 
+// Aligned at the bottom with some extra padding for mobile browsers
 .modal--bottom {
   .modal__main-wrapper {
     top: auto;
     bottom: 0;
     overflow-y: auto;
-    padding-bottom: 80px;
   }
-
-  .modal__content-wrapper {
-    max-height: calc(100vh - 56px);
-    overflow-y: visible;
+  
+  // keep padding in content, not in wrapper, for accurate height measurement
+  // of content (see fef-modal.js@shouldPreventScrolling())
+  .modal__main-content {
+    padding-bottom: 80px;
   }
 }

--- a/source/assets/js/components/fef-modal.js
+++ b/source/assets/js/components/fef-modal.js
@@ -339,6 +339,11 @@ export class FefModal {
      *
      * Additionally, we prevent bouncy body scrolling which can lead to subpar
      * experience on iOS devices.
+     *
+     * One day, this can be solved by `overscroll-behavior: contain;` which
+     * "contains" the scrolling to the current container (exactly what we
+     * need), but for now it's not supported everywhere yet:
+     * https://caniuse.com/#feat=css-overscroll-behavior
      */
     preventScrolling() {
         this.previousScrollPosition = $(window).scrollTop();

--- a/source/assets/js/components/fef-modal.js
+++ b/source/assets/js/components/fef-modal.js
@@ -278,18 +278,19 @@ export class FefModal {
      * - adjusts the animation speed depending on modal height
      * - calls an optional callback
      */
-    slideFromBottom(callBack) {
+    slideFromBottom(callBack = () => {}) {
         this.$element.show();
         let modalHeight = this.$mainWrapper.outerHeight();
         let animationSpeed = (ANIMATION_SPEED > 0) ? ANIMATION_SPEED + (Math.floor(modalHeight / 100) * 25) : 0; // adjusting animation speed
+
+        // bind listener for transitionend to invoke callback after transition ended
+        this.$mainWrapper.one('transitionend', () => callBack());
 
         this.$mainWrapper.css({
             'bottom': `-${modalHeight}px`,
             'transition': `transform ${animationSpeed}ms ease-in-out`,
             'transform': `translateY(-${modalHeight}px)`
         });
-
-        callBack();
     }
 
     /**


### PR DESCRIPTION
Flyouts hatten bisher eine Max-Höhe von `100vh - irgendwas px`, das hat verhindert, dass das Scrollen auf dem Body deaktiviert wurde, sobald der Content höher als der Viewport ist. Zudem wurde das Callback bevor dem Ende der Animation aufgerufen (was in diesem Fall zwar egal war).

Neu schaltet das Modal das Scrolling auf dem Body auch ab, wenn es sich um ein "Bottom-Modal" wie dem Podcast-Flyout handelt.