### PR TITLE
SRFCMSDA-3795 Fixes Background-Color of «Live since x»-Badge

### DIFF
--- a/source/_patterns/20-molecules/ticker/ticker.scss
+++ b/source/_patterns/20-molecules/ticker/ticker.scss
@@ -246,8 +246,8 @@ $ticker-item-border-width: 1px;
   @include fontSize(12);
   line-height: $emphasize-line-height-ratio;
   color: $color-srf-warmgrey-800;
-  background-color: $color-srf-neutral-white;
-  box-shadow: 0 5px 10px 5px $color-srf-neutral-white; // like gradient
+  background-color: $color-srf-neutral-offwhite;
+  box-shadow: 0 5px 10px 5px $color-srf-neutral-offwhite; // like gradient
   position: relative;
   z-index: 1;
 


### PR DESCRIPTION
(should be same as background of `.l-card`)

SRFCMSDA-3795